### PR TITLE
Refactor video aliases and add YouTube download support

### DIFF
--- a/shells/oh-my-zsh/custom/aliases/download_aliases.zsh
+++ b/shells/oh-my-zsh/custom/aliases/download_aliases.zsh
@@ -1,0 +1,908 @@
+# Description: Download related aliases for file downloading operations with various options.
+
+# Helper functions for download aliases
+_show_error_download_aliases() {
+  echo "$1" >&2
+  return 1
+}
+
+_check_command_download_aliases() {
+  if ! command -v "$1" &> /dev/null; then
+    _show_error_download_aliases "Error: Required command \"$1\" not found. Please install it first."
+    return 1
+  fi
+  return 0
+}
+
+_check_integrity_download_aliases() {
+  local file="$1"
+  local hash_type="$2"
+  local expected_hash="$3"
+
+  if [ ! -f "$file" ]; then
+    _show_error_download_aliases "Error: File \"$file\" not found."
+    return 1
+  fi
+
+  # Generate hash based on type
+  local actual_hash=""
+  case "$hash_type" in
+    md5)
+      if command -v md5sum &> /dev/null; then
+        actual_hash=$(md5sum "$file" | awk "{print \$1}")
+      elif command -v md5 &> /dev/null; then
+        # macOS uses md5 instead of md5sum
+        actual_hash=$(md5 -q "$file")
+      else
+        _show_error_download_aliases "Error: Neither md5sum nor md5 command found."
+        return 1
+      fi
+      ;;
+    sha1)
+      if command -v sha1sum &> /dev/null; then
+        actual_hash=$(sha1sum "$file" | awk "{print \$1}")
+      elif command -v shasum &> /dev/null; then
+        actual_hash=$(shasum -a 1 "$file" | awk "{print \$1}")
+      else
+        _show_error_download_aliases "Error: Neither sha1sum nor shasum command found."
+        return 1
+      fi
+      ;;
+    sha256)
+      if command -v sha256sum &> /dev/null; then
+        actual_hash=$(sha256sum "$file" | awk "{print \$1}")
+      elif command -v shasum &> /dev/null; then
+        actual_hash=$(shasum -a 256 "$file" | awk "{print \$1}")
+      else
+        _show_error_download_aliases "Error: Neither sha256sum nor shasum command found."
+        return 1
+      fi
+      ;;
+    *)
+      _show_error_download_aliases "Error: Unsupported hash type \"$hash_type\". Supported types: md5, sha1, sha256."
+      return 1
+      ;;
+  esac
+
+  # Compare hashes (case insensitive)
+  if [ "$(echo "$actual_hash" | tr '[:upper:]' '[:lower:]')" = "$(echo "$expected_hash" | tr '[:upper:]' '[:lower:]')" ]; then
+    echo "Integrity verification passed: $hash_type hash matches."
+    return 0
+  else
+    _show_error_download_aliases "Integrity verification failed: $hash_type hash mismatch."
+    _show_error_download_aliases "Expected: $expected_hash"
+    _show_error_download_aliases "Actual:   $actual_hash"
+    return 1
+  fi
+}
+
+_extract_file_download_aliases() {
+  local file="$1"
+  local target_dir="${2:-$(dirname $file)}"
+
+  if [ ! -f "$file" ]; then
+    _show_error_download_aliases "Error: File \"$file\" not found."
+    return 1
+  fi
+
+  # Create target directory if it doesn"t exist
+  if [ ! -d "$target_dir" ]; then
+    mkdir -p "$target_dir" || {
+      _show_error_download_aliases "Error: Failed to create directory $target_dir."
+      return 1
+    }
+  fi
+
+  echo "Extracting $file to $target_dir..."
+
+  # Extract based on file extension
+  case "$file" in
+    *.tar.gz|*.tgz)
+      tar -xzf "$file" -C "$target_dir"
+      ;;
+    *.tar.bz2|*.tbz2)
+      tar -xjf "$file" -C "$target_dir"
+      ;;
+    *.tar.xz|*.txz)
+      tar -xJf "$file" -C "$target_dir"
+      ;;
+    *.tar)
+      tar -xf "$file" -C "$target_dir"
+      ;;
+    *.gz)
+      gunzip -c "$file" > "$target_dir/$(basename "${file%.gz}")"
+      ;;
+    *.bz2)
+      bunzip2 -c "$file" > "$target_dir/$(basename "${file%.bz2}")"
+      ;;
+    *.zip)
+      unzip -q "$file" -d "$target_dir"
+      ;;
+    *.rar)
+      if command -v unrar &> /dev/null; then
+        unrar x "$file" "$target_dir"
+      else
+        _show_error_download_aliases "Error: unrar command not found. Please install it first."
+        return 1
+      fi
+      ;;
+    *.7z)
+      if command -v 7z &> /dev/null; then
+        7z x "$file" -o"$target_dir"
+      else
+        _show_error_download_aliases "Error: 7z command not found. Please install it first."
+        return 1
+      fi
+      ;;
+    *)
+      _show_error_download_aliases "Error: Unsupported archive format for \"$file\"."
+      return 1
+      ;;
+  esac
+
+  if [ $? -eq 0 ]; then
+    echo "Successfully extracted \"$file\" to \"$target_dir\"."
+    return 0
+  else
+    _show_error_download_aliases "Extraction failed for \"$file\"."
+    return 1
+  fi
+}
+
+# Single file download
+alias dl-file='() {
+  if ! _check_command_download_aliases curl; then
+    return 1
+  fi
+
+  # Parse usage and help
+  if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    echo -e "Download a single file.\nUsage:\n dl-file <url:required> [options]\n\nOptions:\n  -o, --output PATH      : Output path (default: derived from URL)\n  -r, --retries N        : Number of retries (default: 3)\n  -l, --limit SPEED      : Limit download speed (e.g., 1m = 1MB/s)\n  -a, --auto-extract     : Auto extract archive after download\n  -L, --log              : Log download progress to file\n  -H, --header HEADER    : Add custom header (can be used multiple times)\n  -v, --verify HASH:TYPE : Verify file integrity (TYPE: md5, sha1, sha256)\n  -h, --help             : Show this help message\n\nExamples:\n  dl-file https://example.com/file.zip\n  dl-file https://example.com/file.zip -o ~/Downloads/myfile.zip -r 5 -l 1m\n  dl-file https://example.com/file.zip -a -H \"Authorization: Bearer token\"\n  dl-file https://example.com/file.zip -v d41d8cd98f00b204e9800998ecf8427e:md5"
+    return 0
+  fi
+
+  local url="$1"
+  shift
+
+  # Default values
+  local output_path=""
+  local retries=3
+  local limit_speed=""
+  local auto_extract=false
+  local log_enabled=false
+  local log_file=""
+  local headers=()
+  local verify_hash=""
+  local verify_type=""
+
+  # Parse options
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output)
+        output_path="$2"
+        shift 2
+        ;;
+      -r|--retries)
+        retries="$2"
+        shift 2
+        ;;
+      -l|--limit)
+        limit_speed="$2"
+        shift 2
+        ;;
+      -a|--auto-extract)
+        auto_extract=true
+        shift
+        ;;
+      -L|--log)
+        log_enabled=true
+        shift
+        ;;
+      -H|--header)
+        headers+=("$2")
+        shift 2
+        ;;
+      -v|--verify)
+        IFS=":" read -r verify_hash verify_type <<< "$2"
+        shift 2
+        ;;
+      *)
+        _show_error_download_aliases "Error: Unknown option \"$1\""
+        return 1
+        ;;
+    esac
+  done
+
+  # Determine output path if not provided
+  if [ -z "$output_path" ]; then
+    output_path="$(basename "$url")"
+  fi
+
+  # Create directory if it doesn"t exist
+  local dir_path=$(dirname "$output_path")
+  if [ ! -d "$dir_path" ] && [ "$dir_path" != "." ]; then
+    if ! mkdir -p "$dir_path"; then
+      _show_error_download_aliases "Failed to create directory: $dir_path"
+      return 1
+    fi
+  fi
+
+  # Set up logging
+  if $log_enabled; then
+    log_file="${output_path}.log"
+    echo "Download started at $(date)" > "$log_file"
+    echo "URL: $url" >> "$log_file"
+  fi
+
+  # Prepare curl command
+  local curl_opts=("-L" "-o" "$output_path" "--retry" "$retries")
+
+  # Add limit speed option
+  if [ -n "$limit_speed" ]; then
+    curl_opts+=("--limit-rate" "$limit_speed")
+    [ $log_enabled = true ] && echo "Speed limit: $limit_speed" >> "$log_file"
+  fi
+
+  # Add headers
+  for header in "${headers[@]}"; do
+    curl_opts+=("-H" "$header")
+    [ $log_enabled = true ] && echo "Header: $header" >> "$log_file"
+  done
+
+  # Download progress settings
+  if [ -t 1 ]; then  # If terminal is interactive
+    curl_opts+=("--progress-bar")
+  else
+    curl_opts+=("-s")
+  fi
+
+  echo "Downloading from $url to $output_path..."
+
+  # Run the download
+  if $log_enabled; then
+    curl "${curl_opts[@]}" "$url" 2>> "$log_file"
+  else
+    curl "${curl_opts[@]}" "$url"
+  fi
+
+  local status=$?
+  if [ $status -ne 0 ]; then
+    _show_error_download_aliases "Download failed. Check the URL and your internet connection."
+    [ $log_enabled = true ] && echo "Download failed with status $status at $(date)" >> "$log_file"
+    return 1
+  fi
+
+  echo "Download complete: $output_path"
+  [ $log_enabled = true ] && echo "Download completed successfully at $(date)" >> "$log_file"
+
+  # Verify file integrity if requested
+  if [ -n "$verify_hash" ] && [ -n "$verify_type" ]; then
+    echo "Verifying file integrity using $verify_type hash..."
+    [ $log_enabled = true ] && echo "Verifying file integrity using $verify_type hash..." >> "$log_file"
+
+    if ! _check_integrity_download_aliases "$output_path" "$verify_type" "$verify_hash"; then
+      [ $log_enabled = true ] && echo "Integrity verification failed" >> "$log_file"
+      return 1
+    fi
+
+    [ $log_enabled = true ] && echo "Integrity verification passed" >> "$log_file"
+  fi
+
+  # Auto extract if requested
+  if $auto_extract; then
+    echo "Auto-extracting downloaded file..."
+    [ $log_enabled = true ] && echo "Auto-extracting downloaded file..." >> "$log_file"
+
+    if ! _extract_file_download_aliases "$output_path"; then
+      [ $log_enabled = true ] && echo "Extraction failed" >> "$log_file"
+      return 1
+    fi
+
+    [ $log_enabled = true ] && echo "Extraction completed successfully" >> "$log_file"
+  fi
+
+  return 0
+}' # Download a single file with options
+
+# Batch download from a list of URLs
+alias dl-batch='() {
+  if ! _check_command_download_aliases curl; then
+    return 1
+  fi
+
+  # Parse usage and help
+  if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    echo -e "Batch download multiple files from a list of URLs.\nUsage:\n dl-batch <url_list_file:required|url1 url2...> [options]\n\nOptions:\n  -o, --output-dir DIR   : Output directory (default: current directory)\n  -r, --retries N        : Number of retries (default: 3)\n  -l, --limit SPEED      : Limit download speed (e.g., 1m = 1MB/s)\n  -a, --auto-extract     : Auto extract archives after download\n  -L, --log              : Log download progress to file\n  -H, --header HEADER    : Add custom header (can be used multiple times)\n  -p, --parallel N       : Number of parallel downloads (default: 1)\n  -h, --help             : Show this help message\n\nExamples:\n  dl-batch urls.txt -o ~/Downloads -r 5 -l 1m\n  dl-batch https://example.com/file1.zip https://example.com/file2.zip -a\n  dl-batch urls.txt -p 3 -H \"Authorization: Bearer token\""
+    return 0
+  fi
+
+  # Check if first argument is a file or a URL
+  local url_list=()
+  if [ -f "$1" ]; then
+    # Read URLs from file
+    while IFS= read -r line || [ -n "$line" ]; do
+      # Skip empty lines and comments
+      [[ -z "$line" || "$line" =~ ^# ]] && continue
+      url_list+=("$line")
+    done < "$1"
+    shift
+  else
+    # Collect URLs from command line until we hit an option
+    while [[ $# -gt 0 && ! "$1" =~ ^- ]]; do
+      url_list+=("$1")
+      shift
+    done
+  fi
+
+  # Check if we have any URLs
+  if [ ${#url_list[@]} -eq 0 ]; then
+    _show_error_download_aliases "Error: No URLs provided."
+    return 1
+  fi
+
+  # Default values
+  local output_dir="."
+  local retries=3
+  local limit_speed=""
+  local auto_extract=false
+  local log_enabled=false
+  local log_file="dl-batch.log"
+  local headers=()
+  local parallel=1
+
+  # Parse options
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output-dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -r|--retries)
+        retries="$2"
+        shift 2
+        ;;
+      -l|--limit)
+        limit_speed="$2"
+        shift 2
+        ;;
+      -a|--auto-extract)
+        auto_extract=true
+        shift
+        ;;
+      -L|--log)
+        log_enabled=true
+        shift
+        ;;
+      -H|--header)
+        headers+=("$2")
+        shift 2
+        ;;
+      -p|--parallel)
+        parallel="$2"
+        shift 2
+        ;;
+      *)
+        _show_error_download_aliases "Error: Unknown option \"$1\""
+        return 1
+        ;;
+    esac
+  done
+
+  # Create output directory if it doesn"t exist
+  if [ ! -d "$output_dir" ]; then
+    if ! mkdir -p "$output_dir"; then
+      _show_error_download_aliases "Failed to create directory: $output_dir"
+      return 1
+    fi
+  fi
+
+  # Set up logging
+  if $log_enabled; then
+    log_file="${output_dir}/${log_file}"
+    echo "Batch download started at $(date)" > "$log_file"
+    echo "Number of URLs: ${#url_list[@]}" >> "$log_file"
+  fi
+
+  # Download files
+  echo "Starting batch download of ${#url_list[@]} files to $output_dir..."
+
+  # Check for parallel download capabilities
+  local use_parallel=false
+  if [ "$parallel" -gt 1 ]; then
+    if ! _check_command_download_aliases xargs; then
+      echo "Warning: xargs not found, falling back to sequential downloads."
+    elif ! _check_command_download_aliases parallel; then
+      echo "Warning: GNU parallel not found, falling back to sequential downloads."
+    else
+      use_parallel=true
+    fi
+  fi
+
+  local success_count=0
+  local fail_count=0
+
+  if $use_parallel; then
+    # Create a temporary file for the URLs
+    local tmp_file=$(mktemp)
+    for url in "${url_list[@]}"; do
+      echo "$url" >> "$tmp_file"
+    done
+
+    # Build the download command with options
+    local cmd="dl-file {} -o ${output_dir}/\$(basename {}) -r $retries"
+    [ -n "$limit_speed" ] && cmd+=" -l $limit_speed"
+    $auto_extract && cmd+=" -a"
+    $log_enabled && cmd+=" -L"
+    for header in "${headers[@]}"; do
+      cmd+=" -H \"$header\""
+    done
+
+    # Run the parallel downloads
+    echo "Running $parallel parallel downloads..."
+    cat "$tmp_file" | parallel -j "$parallel" "$cmd"
+
+    # Count results (approximate)
+    success_count=$(ls -la "$output_dir" | wc -l)
+    success_count=$((success_count - 2))  # Adjust for . and .. entries
+    fail_count=$((${#url_list[@]} - success_count))
+
+    # Clean up
+    rm "$tmp_file"
+  else
+    # Sequential downloads
+    for url in "${url_list[@]}"; do
+      local filename=$(basename "$url")
+      local output_path="${output_dir}/${filename}"
+
+      echo "Downloading $url to $output_path..."
+      [ $log_enabled = true ] && echo "Downloading $url to $output_path..." >> "$log_file"
+
+      # Prepare curl command
+      local curl_opts=("-L" "-o" "$output_path" "--retry" "$retries")
+
+      # Add limit speed option
+      [ -n "$limit_speed" ] && curl_opts+=("--limit-rate" "$limit_speed")
+
+      # Add headers
+      for header in "${headers[@]}"; do
+        curl_opts+=("-H" "$header")
+      done
+
+      # Download progress settings
+      if [ -t 1 ]; then  # If terminal is interactive
+        curl_opts+=("--progress-bar")
+      else
+        curl_opts+=("-s")
+      fi
+
+      # Run the download
+      curl "${curl_opts[@]}" "$url"
+
+      if [ $? -eq 0 ]; then
+        echo "Successfully downloaded $url"
+        [ $log_enabled = true ] && echo "Successfully downloaded $url" >> "$log_file"
+        ((success_count++))
+
+        # Auto extract if requested
+        if $auto_extract; then
+          echo "Auto-extracting $output_path..."
+          [ $log_enabled = true ] && echo "Auto-extracting $output_path..." >> "$log_file"
+
+          if _extract_file_download_aliases "$output_path" "$output_dir"; then
+            [ $log_enabled = true ] && echo "Extraction completed successfully" >> "$log_file"
+          else
+            [ $log_enabled = true ] && echo "Extraction failed" >> "$log_file"
+          fi
+        fi
+      else
+        echo "Failed to download $url"
+        [ $log_enabled = true ] && echo "Failed to download $url" >> "$log_file"
+        ((fail_count++))
+      fi
+    done
+  fi
+
+  # Print summary
+  echo "Batch download summary:"
+  echo "  Successfully downloaded: $success_count"
+  echo "  Failed: $fail_count"
+
+  if $log_enabled; then
+    echo "Batch download completed at $(date)" >> "$log_file"
+    echo "Summary:" >> "$log_file"
+    echo "  Successfully downloaded: $success_count" >> "$log_file"
+    echo "  Failed: $fail_count" >> "$log_file"
+  fi
+
+  # Return error if any downloads failed
+  if [ $fail_count -gt 0 ]; then
+    return 1
+  fi
+
+  return 0
+}' # Batch download multiple files from a list of URLs
+
+# Download from URL with options to resume downloads
+alias dl-resume='() {
+  if ! _check_command_download_aliases curl; then
+    return 1
+  fi
+
+  # Parse usage and help
+  if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    echo -e "Download a file with resume capability.\nUsage:\n dl-resume <url:required> [options]\n\nOptions:\n  -o, --output PATH      : Output path (default: derived from URL)\n  -r, --retries N        : Number of retries (default: 3)\n  -l, --limit SPEED      : Limit download speed (e.g., 1m = 1MB/s)\n  -a, --auto-extract     : Auto extract archive after download\n  -L, --log              : Log download progress to file\n  -H, --header HEADER    : Add custom header (can be used multiple times)\n  -v, --verify HASH:TYPE : Verify file integrity (TYPE: md5, sha1, sha256)\n  -h, --help             : Show this help message\n\nExamples:\n  dl-resume https://example.com/large-file.zip\n  dl-resume https://example.com/large-file.zip -o ~/Downloads/myfile.zip -r 5 -l 1m\n  dl-resume https://example.com/large-file.zip -a -H \"Authorization: Bearer token\""
+    return 0
+  fi
+
+  local url="$1"
+  shift
+
+  # Default values
+  local output_path=""
+  local retries=3
+  local limit_speed=""
+  local auto_extract=false
+  local log_enabled=false
+  local log_file=""
+  local headers=()
+  local verify_hash=""
+  local verify_type=""
+
+  # Parse options (same as dl-file)
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output)
+        output_path="$2"
+        shift 2
+        ;;
+      -r|--retries)
+        retries="$2"
+        shift 2
+        ;;
+      -l|--limit)
+        limit_speed="$2"
+        shift 2
+        ;;
+      -a|--auto-extract)
+        auto_extract=true
+        shift
+        ;;
+      -L|--log)
+        log_enabled=true
+        shift
+        ;;
+      -H|--header)
+        headers+=("$2")
+        shift 2
+        ;;
+      -v|--verify)
+        IFS=":" read -r verify_hash verify_type <<< "$2"
+        shift 2
+        ;;
+      *)
+        _show_error_download_aliases "Error: Unknown option \"$1\""
+        return 1
+        ;;
+    esac
+  done
+
+  # Determine output path if not provided
+  if [ -z "$output_path" ]; then
+    output_path="$(basename "$url")"
+  fi
+
+  # Create directory if it doesn"t exist
+  local dir_path=$(dirname "$output_path")
+  if [ ! -d "$dir_path" ] && [ "$dir_path" != "." ]; then
+    if ! mkdir -p "$dir_path"; then
+      _show_error_download_aliases "Failed to create directory: $dir_path"
+      return 1
+    fi
+  fi
+
+  # Set up logging
+  if $log_enabled; then
+    log_file="${output_path}.log"
+    echo "Download started at $(date)" > "$log_file"
+    echo "URL: $url" >> "$log_file"
+  fi
+
+  # Prepare curl command with resume
+  local curl_opts=("-L" "-C" "-" "-o" "$output_path" "--retry" "$retries")
+
+  # Add limit speed option
+  if [ -n "$limit_speed" ]; then
+    curl_opts+=("--limit-rate" "$limit_speed")
+    [ $log_enabled = true ] && echo "Speed limit: $limit_speed" >> "$log_file"
+  fi
+
+  # Add headers
+  for header in "${headers[@]}"; do
+    curl_opts+=("-H" "$header")
+    [ $log_enabled = true ] && echo "Header: $header" >> "$log_file"
+  fi
+
+  # Download progress settings
+  if [ -t 1 ]; then  # If terminal is interactive
+    curl_opts+=("--progress-bar")
+  else
+    curl_opts+=("-s")
+  fi
+
+  echo "Downloading from $url to $output_path (with resume capability)..."
+
+  # Run the download
+  if $log_enabled; then
+    curl "${curl_opts[@]}" "$url" 2>> "$log_file"
+  else
+    curl "${curl_opts[@]}" "$url"
+  fi
+
+  local status=$?
+  if [ $status -ne 0 ]; then
+    _show_error_download_aliases "Download failed. Check the URL and your internet connection."
+    [ $log_enabled = true ] && echo "Download failed with status $status at $(date)" >> "$log_file"
+    return 1
+  fi
+
+  echo "Download complete: $output_path"
+  [ $log_enabled = true ] && echo "Download completed successfully at $(date)" >> "$log_file"
+
+  # Verify file integrity if requested (same as dl-file)
+  if [ -n "$verify_hash" ] && [ -n "$verify_type" ]; then
+    echo "Verifying file integrity using $verify_type hash..."
+    [ $log_enabled = true ] && echo "Verifying file integrity using $verify_type hash..." >> "$log_file"
+
+    if ! _check_integrity_download_aliases "$output_path" "$verify_type" "$verify_hash"; then
+      [ $log_enabled = true ] && echo "Integrity verification failed" >> "$log_file"
+      return 1
+    fi
+
+    [ $log_enabled = true ] && echo "Integrity verification passed" >> "$log_file"
+  fi
+
+  # Auto extract if requested (same as dl-file)
+  if $auto_extract; then
+    echo "Auto-extracting downloaded file..."
+    [ $log_enabled = true ] && echo "Auto-extracting downloaded file..." >> "$log_file"
+
+    if ! _extract_file_download_aliases "$output_path"; then
+      [ $log_enabled = true ] && echo "Extraction failed" >> "$log_file"
+      return 1
+    fi
+
+    [ $log_enabled = true ] && echo "Extraction completed successfully" >> "$log_file"
+  fi
+
+  return 0
+}' # Download a file with resume capability
+
+# Mirror an entire website for offline viewing
+alias dl-mirror='() {
+  if ! _check_command_download_aliases wget; then
+    return 1
+  fi
+
+  # Parse usage and help
+  if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    echo -e "Mirror a website for offline viewing.\nUsage:\n dl-mirror <url:required> [options]\n\nOptions:\n  -o, --output-dir DIR   : Output directory (default: ./mirror)\n  -d, --depth LEVEL      : Maximum depth level for recursion (default: 5)\n  -l, --limit SPEED      : Limit download speed (e.g., 1m = 1MB/s)\n  -w, --wait SECONDS     : Wait between retrievals (default: 1)\n  -H, --header HEADER    : Add custom header (can be used multiple times)\n  -h, --help             : Show this help message\n\nExamples:\n  dl-mirror https://example.com\n  dl-mirror https://example.com -o ~/websites/example -d 3 -l 500k\n  dl-mirror https://example.com -H \"Authorization: Bearer token\""
+    return 0
+  fi
+
+  local url="$1"
+  shift
+
+  # Default values
+  local output_dir="./mirror"
+  local depth=5
+  local limit_speed=""
+  local wait_time=1
+  local headers=()
+
+  # Parse options
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output-dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -d|--depth)
+        depth="$2"
+        shift 2
+        ;;
+      -l|--limit)
+        limit_speed="$2"
+        shift 2
+        ;;
+      -w|--wait)
+        wait_time="$2"
+        shift 2
+        ;;
+      -H|--header)
+        headers+=("$2")
+        shift 2
+        ;;
+      *)
+        _show_error_download_aliases "Error: Unknown option \"$1\""
+        return 1
+        ;;
+    esac
+  done
+
+  # Create output directory if it doesn"t exist
+  if [ ! -d "$output_dir" ]; then
+    if ! mkdir -p "$output_dir"; then
+      _show_error_download_aliases "Failed to create directory: $output_dir"
+      return 1
+    fi
+  fi
+
+  # Prepare wget command
+  local wget_opts=(
+    "--mirror"
+    "--convert-links"
+    "--adjust-extension"
+    "--page-requisites"
+    "--no-parent"
+    "-P" "$output_dir"
+    "--level=$depth"
+    "--wait=$wait_time"
+    "--random-wait"
+    "--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+  )
+
+  # Add limit speed option
+  if [ -n "$limit_speed" ]; then
+    wget_opts+=("--limit-rate=$limit_speed")
+  fi
+
+  # Add headers
+  for header in "${headers[@]}"; do
+    wget_opts+=("--header=$header")
+  done
+
+  echo "Mirroring website $url to $output_dir (depth: $depth)..."
+  wget "${wget_opts[@]}" "$url"
+
+  local status=$?
+  if [ $status -ne 0 ]; then
+    _show_error_download_aliases "Website mirroring failed."
+    return 1
+  fi
+
+  echo "Website mirroring complete: $output_dir"
+  return 0
+}' # Mirror a website for offline viewing
+
+# Download and extract in one step
+alias dl-extract='() {
+  if ! _check_command_download_aliases curl; then
+    return 1
+  fi
+
+  # Parse usage and help
+  if [ $# -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    echo -e "Download and extract archive in one step.\nUsage:\n dl-extract <url:required> [options]\n\nOptions:\n  -o, --output-dir DIR   : Output directory (default: current directory)\n  -r, --retries N        : Number of retries (default: 3)\n  -l, --limit SPEED      : Limit download speed (e.g., 1m = 1MB/s)\n  -k, --keep-archive     : Keep the archive file after extraction\n  -H, --header HEADER    : Add custom header (can be used multiple times)\n  -h, --help             : Show this help message\n\nExamples:\n  dl-extract https://example.com/archive.zip\n  dl-extract https://example.com/archive.tar.gz -o ~/extracted -r 5 -l 1m\n  dl-extract https://example.com/archive.zip -k -H \"Authorization: Bearer token\""
+    return 0
+  fi
+
+  local url="$1"
+  shift
+
+  # Default values
+  local output_dir="."
+  local retries=3
+  local limit_speed=""
+  local keep_archive=false
+  local headers=()
+
+  # Parse options
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output-dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -r|--retries)
+        retries="$2"
+        shift 2
+        ;;
+      -l|--limit)
+        limit_speed="$2"
+        shift 2
+        ;;
+      -k|--keep-archive)
+        keep_archive=true
+        shift
+        ;;
+      -H|--header)
+        headers+=("$2")
+        shift 2
+        ;;
+      *)
+        _show_error_download_aliases "Error: Unknown option \"$1\""
+        return 1
+        ;;
+    esac
+  done
+
+  # Create output directory if it doesn"t exist
+  if [ ! -d "$output_dir" ]; then
+    if ! mkdir -p "$output_dir"; then
+      _show_error_download_aliases "Failed to create directory: $output_dir"
+      return 1
+    fi
+  fi
+
+  # Get filename from URL
+  local filename=$(basename "$url")
+  local temp_dir=$(mktemp -d)
+  local archive_path="${temp_dir}/${filename}"
+
+  echo "Downloading from $url..."
+
+  # Prepare curl command
+  local curl_opts=("-L" "-o" "$archive_path" "--retry" "$retries")
+
+  # Add limit speed option
+  [ -n "$limit_speed" ] && curl_opts+=("--limit-rate" "$limit_speed")
+
+  # Add headers
+  for header in "${headers[@]}"; do
+    curl_opts+=("-H" "$header")
+  done
+
+  # Download progress settings
+  if [ -t 1 ]; then  # If terminal is interactive
+    curl_opts+=("--progress-bar")
+  else
+    curl_opts+=("-s")
+  fi
+
+  # Run the download
+  curl "${curl_opts[@]}" "$url"
+
+  if [ $? -ne 0 ]; then
+    _show_error_download_aliases "Download failed. Check the URL and your internet connection."
+    rm -rf "$temp_dir"
+    return 1
+  fi
+
+  echo "Download complete, extracting..."
+
+  # Extract the archive
+  if ! _extract_file_download_aliases "$archive_path" "$output_dir"; then
+    _show_error_download_aliases "Extraction failed."
+    rm -rf "$temp_dir"
+    return 1
+  fi
+
+  # Keep or remove the archive
+  if $keep_archive; then
+    echo "Moving archive to output directory..."
+    mv "$archive_path" "$output_dir/"
+  fi
+
+  # Clean up
+  rm -rf "$temp_dir"
+
+  echo "Download and extraction complete!"
+  return 0
+}' # Download and extract archive in one step
+
+# Help function that lists all available download aliases
+alias dl-help='() {
+  echo "Download Aliases Help"
+  echo "===================="
+  echo ""
+  echo "Available commands:"
+  echo ""
+  echo "dl-file <url> [options]            - Download a single file"
+  echo "dl-batch <url_list> [options]      - Batch download multiple files"
+  echo "dl-resume <url> [options]          - Download with resume capability"
+  echo "dl-mirror <url> [options]          - Mirror a website for offline viewing"
+  echo "dl-extract <url> [options]         - Download and extract in one step"
+  echo "dl-help                            - Show this help message"
+  echo ""
+  echo "Use any command with -h or --help for detailed usage information."
+}' # Show help for download aliases

--- a/shells/oh-my-zsh/custom/aliases/video_aliases.zsh
+++ b/shells/oh-my-zsh/custom/aliases/video_aliases.zsh
@@ -1,4 +1,4 @@
-# Description: Video processing aliases for conversion, compression, merging, and format transformation using ffmpeg and youtube-dl.
+# Description: Video processing aliases for conversion, compression, merging, and format transformation using ffmpeg.
 
 #------------------------------------------------------------------------------
 # Helper Functions
@@ -697,109 +697,6 @@ alias vdo-convert-m3u8-to-mp4='() {
     return 1
   fi
 }' # Convert M3U8 stream to MP4 video
-
-#------------------------------------------------------------------------------
-# YouTube Downloads
-#------------------------------------------------------------------------------
-
-_vdo_check_youtube_dl='() {
-  if ! command -v youtube-dl &> /dev/null; then
-    echo "Error: youtube-dl is not installed or not in PATH" >&2
-    return 1
-  fi
-  return 0
-}'
-
-alias vdo-youtube-best='() {
-  echo "Download best quality YouTube video."
-  echo "Usage:"
-  echo "  vdo-youtube-best <youtube_url>"
-
-  if [ $# -eq 0 ]; then
-    return 1
-  fi
-
-  _vdo_check_youtube_dl || return 1
-  youtube-dl -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo+bestaudio" --merge-output-format mp4 "$@"
-}' # Download best quality YouTube video
-
-alias vdo-youtube-complete='() {
-  echo "Download YouTube video with subtitles and thumbnail."
-  echo "Usage:"
-  echo "  vdo-youtube-complete <youtube_url>"
-
-  if [ $# -eq 0 ]; then
-    return 1
-  fi
-
-  _vdo_check_youtube_dl || return 1
-  youtube-dl -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo+bestaudio" --merge-output-format mp4 --all-subs --embed-subs --embed-thumbnail -o "%(title)s.%(ext)s" "$@"
-}' # Download YouTube video with subtitles and thumbnail
-
-alias vdo-youtube-720p='() {
-  echo "Download 720p YouTube video."
-  echo "Usage:"
-  echo "  vdo-youtube-720p <youtube_url>"
-
-  if [ $# -eq 0 ]; then
-    return 1
-  fi
-
-  _vdo_check_youtube_dl || return 1
-  youtube-dl -f "bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/bestvideo[height<=720]+bestaudio" --merge-output-format mp4 "$@"
-}' # Download 720p YouTube video
-
-alias vdo-youtube-1080p='() {
-  echo "Download 1080p YouTube video."
-  echo "Usage:"
-  echo "  vdo-youtube-1080p <youtube_url>"
-
-  if [ $# -eq 0 ]; then
-    return 1
-  fi
-
-  _vdo_check_youtube_dl || return 1
-  youtube-dl -f "bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/bestvideo[height<=1080]+bestaudio" --merge-output-format mp4 "$@"
-}' # Download 1080p YouTube video
-
-alias vdo-youtube-mp3='() {
-  echo "Download YouTube audio as MP3."
-  echo "Usage:"
-  echo "  vdo-youtube-mp3 <youtube_url>"
-
-  if [ $# -eq 0 ]; then
-    return 1
-  fi
-
-  _vdo_check_youtube_dl || return 1
-  youtube-dl -f bestaudio --extract-audio --audio-format mp3 "$@"
-}' # Download YouTube audio as MP3
-
-alias vdo-youtube-mp3-128='() {
-  echo "Download YouTube audio as MP3 with 128K quality."
-  echo "Usage:"
-  echo "  vdo-youtube-mp3-128 <youtube_url>"
-
-  if [ $# -eq 0 ]; then
-    return 1
-  fi
-
-  _vdo_check_youtube_dl || return 1
-  youtube-dl -f bestaudio --extract-audio --audio-format mp3 --audio-quality 128K "$@"
-}' # Download YouTube audio as MP3 with 128K quality
-
-alias vdo-youtube-mp3-320='() {
-  echo "Download YouTube audio as MP3 with 320K quality."
-  echo "Usage:"
-  echo "  vdo-youtube-mp3-320 <youtube_url>"
-
-  if [ $# -eq 0 ]; then
-    return 1
-  fi
-
-  _vdo_check_youtube_dl || return 1
-  youtube-dl -f bestaudio --extract-audio --audio-format mp3 --audio-quality 320K "$@"
-}' # Download YouTube audio as MP3 with 320K quality
 
 #------------------------------------------------------------------------------
 # Video Information & Metadata
@@ -1766,15 +1663,6 @@ alias vdo-help='() {
   echo "  vdo-create-preview-grid <file> <cols>   - Create a grid of screenshots"
   echo "  vdo-screenshot <file> [options]         - Capture screenshots from a video"
   echo "  vdo-batch-screenshot <dir> [options]    - Capture screenshots from videos in a directory"
-  echo ""
-  echo "YouTube Downloads:"
-  echo "  vdo-youtube-best <url>               - Download best quality YouTube video"
-  echo "  vdo-youtube-complete <url>           - Download YouTube video with subtitles and thumbnail"
-  echo "  vdo-youtube-720p <url>               - Download 720p YouTube video"
-  echo "  vdo-youtube-1080p <url>              - Download 1080p YouTube video"
-  echo "  vdo-youtube-mp3 <url>                - Download YouTube audio as MP3"
-  echo "  vdo-youtube-mp3-128 <url>            - Download YouTube audio as MP3 with 128K quality"
-  echo "  vdo-youtube-mp3-320 <url>            - Download YouTube audio as MP3 with 320K quality"
   echo ""
   echo "For more detailed help on any command, run the command without arguments"
 }' # Display help information about all video commands

--- a/shells/oh-my-zsh/custom/aliases/youtube_aliases.zsh
+++ b/shells/oh-my-zsh/custom/aliases/youtube_aliases.zsh
@@ -1,0 +1,1558 @@
+# Description: YouTube video download aliases using yt-dlp for downloading videos, playlists, subtitles, thumbnails, and extracting audio.
+
+#------------------------------------------------------------------------------
+# Helper Functions
+#------------------------------------------------------------------------------
+
+# Helper function to validate if a URL is provided
+_yt_validate_url() {
+  if [[ -z "$1" ]]; then
+    echo "Error: No URL provided" >&2
+    return 1
+  fi
+
+  # Basic URL validation
+  if [[ ! "$1" =~ ^https?:// ]]; then
+    echo "Error: Invalid URL format. URL must start with http:// or https://" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+# Helper function to validate if a directory exists, create if specified
+_yt_validate_dir() {
+  local dir="$1"
+  local create="$2"
+
+  if [[ ! -d "$dir" ]]; then
+    if [[ "$create" == "create" ]]; then
+      mkdir -p "$dir" || {
+        echo "Error: Failed to create directory \"$dir\"" >&2
+        return 1
+      }
+      echo "Created directory: $dir"
+    else
+      echo "Error: Directory \"$dir\" does not exist" >&2
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
+# Helper function to check if yt-dlp is installed
+_yt_check_ytdlp() {
+  if ! command -v yt-dlp &> /dev/null; then
+    echo "Error: yt-dlp is not installed or not in PATH" >&2
+    echo "Install it with: pip install yt-dlp" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+# Helper function to check if ffmpeg is installed
+_yt_check_ffmpeg() {
+  if ! command -v ffmpeg &> /dev/null; then
+    echo "Error: ffmpeg is not installed or not in PATH" >&2
+    echo "Install it with brew install ffmpeg (macOS) or apt install ffmpeg (Linux)" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+#------------------------------------------------------------------------------
+# Video Download Aliases
+#------------------------------------------------------------------------------
+
+alias yt-download='() {
+  echo -e "Download a YouTube video.\nUsage:\n  yt-download <video_url> [options]\n\nOptions:\n  -o, --output_dir DIR   : Output directory (default: current directory)\n  -f, --format FORMAT    : Video format/quality (default: best)\n                          Common formats: best, 720p, 1080p, 2160p\n  -s, --subtitles        : Download subtitles if available\n  -t, --thumbnail        : Download thumbnail\n  -i, --info             : Display video info without downloading\n  -h, --help             : Show this help message\n\nExamples:\n  yt-download https://youtu.be/dQw4w9WgXcQ\n  yt-download https://youtu.be/dQw4w9WgXcQ -f 720p -s -t\n  yt-download https://youtu.be/dQw4w9WgXcQ --output_dir ~/Downloads --format 1080p"
+
+  # Variables with default values
+  local url=""
+  local output_dir="."
+  local format="best"
+  local download_subs=false
+  local download_thumbnail=false
+  local show_info_only=false
+  local show_help=false
+  local ytdlp_args=""
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output_dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -f|--format)
+        format="$2"
+        shift 2
+        ;;
+      -s|--subtitles)
+        download_subs=true
+        shift
+        ;;
+      -t|--thumbnail)
+        download_thumbnail=true
+        shift
+        ;;
+      -i|--info)
+        show_info_only=true
+        shift
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL
+        if [ -z "$url" ]; then
+          url="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL provided
+  if $show_help || [ -z "$url" ]; then
+    return 1
+  fi
+
+  # Validate URL and check for yt-dlp
+  _yt_validate_url "$url" || return 1
+  _yt_check_ytdlp || return 1
+
+  # Validate output directory
+  _yt_validate_dir "$output_dir" "create" || return 1
+
+  # Prepare format specification
+  local format_arg=""
+  case "$format" in
+    best)
+      format_arg="bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"
+      ;;
+    720p)
+      format_arg="bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720][ext=mp4]/best"
+      ;;
+    1080p)
+      format_arg="bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[height<=1080][ext=mp4]/best"
+      ;;
+    2160p)
+      format_arg="bestvideo[height<=2160][ext=mp4]+bestaudio[ext=m4a]/best[height<=2160][ext=mp4]/best"
+      ;;
+    *)
+      format_arg="$format"
+      ;;
+  esac
+
+  # Build yt-dlp arguments
+  ytdlp_args="$ytdlp_args -f \"$format_arg\" -o \"$output_dir/%(title)s.%(ext)s\""
+
+  if $download_subs; then
+    ytdlp_args="$ytdlp_args --write-auto-sub --sub-lang en --convert-subs srt"
+  fi
+
+  if $download_thumbnail; then
+    ytdlp_args="$ytdlp_args --write-thumbnail"
+  fi
+
+  if $show_info_only; then
+    echo "Video information for: $url"
+    yt-dlp --dump-json "$url" | jq "{id, title, upload_date, uploader, duration, view_count, like_count}"
+    return 0
+  fi
+
+  # Execute the download
+  echo "Downloading video from $url with format: $format"
+  eval "yt-dlp $ytdlp_args \"$url\""
+
+  if [ $? -eq 0 ]; then
+    echo "Download completed successfully to $output_dir"
+  else
+    echo "Error: Download failed" >&2
+    return 1
+  fi
+}' # Download a YouTube video with options
+
+alias yt-batch-download='() {
+  echo -e "Batch download YouTube videos from a file containing URLs.\nUsage:\n  yt-batch-download <url_file_path> [options]\n\nOptions:\n  -o, --output_dir DIR   : Output directory (default: current directory)\n  -f, --format FORMAT    : Video format/quality (default: best)\n                          Common formats: best, 720p, 1080p, 2160p\n  -s, --subtitles        : Download subtitles if available\n  -t, --thumbnail        : Download thumbnail\n  -h, --help             : Show this help message\n\nExamples:\n  yt-batch-download urls.txt\n  yt-batch-download urls.txt -f 720p -s -t\n  yt-batch-download urls.txt --output_dir ~/Downloads --format 1080p"
+
+  # Variables with default values
+  local url_file=""
+  local output_dir="."
+  local format="best"
+  local download_subs=false
+  local download_thumbnail=false
+  local show_help=false
+  local ytdlp_args=""
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output_dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -f|--format)
+        format="$2"
+        shift 2
+        ;;
+      -s|--subtitles)
+        download_subs=true
+        shift
+        ;;
+      -t|--thumbnail)
+        download_thumbnail=true
+        shift
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL file
+        if [ -z "$url_file" ]; then
+          url_file="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL file provided
+  if $show_help || [ -z "$url_file" ]; then
+    return 1
+  fi
+
+  # Check if the URL file exists
+  if [ ! -f "$url_file" ]; then
+    echo "Error: File \"$url_file\" does not exist" >&2
+    return 1
+  fi
+
+  # Check for yt-dlp
+  _yt_check_ytdlp || return 1
+
+  # Validate output directory
+  _yt_validate_dir "$output_dir" "create" || return 1
+
+  # Prepare format specification
+  local format_arg=""
+  case "$format" in
+    best)
+      format_arg="bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"
+      ;;
+    720p)
+      format_arg="bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720][ext=mp4]/best"
+      ;;
+    1080p)
+      format_arg="bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[height<=1080][ext=mp4]/best"
+      ;;
+    2160p)
+      format_arg="bestvideo[height<=2160][ext=mp4]+bestaudio[ext=m4a]/best[height<=2160][ext=mp4]/best"
+      ;;
+    *)
+      format_arg="$format"
+      ;;
+  esac
+
+  # Build yt-dlp arguments
+  ytdlp_args="$ytdlp_args -f \"$format_arg\" -o \"$output_dir/%(title)s.%(ext)s\""
+
+  if $download_subs; then
+    ytdlp_args="$ytdlp_args --write-auto-sub --sub-lang en --convert-subs srt"
+  fi
+
+  if $download_thumbnail; then
+    ytdlp_args="$ytdlp_args --write-thumbnail"
+  fi
+
+  # Execute the download
+  echo "Batch downloading videos from URLs in $url_file with format: $format"
+
+  # Count total URLs
+  local total_urls=$(grep -c "^https\?://" "$url_file")
+  local success_count=0
+  local error_count=0
+  local current=0
+
+  while IFS= read -r url || [ -n "$url" ]; do
+    # Skip empty lines or comments
+    if [[ -z "$url" || "$url" =~ ^# ]]; then
+      continue
+    fi
+
+    # Skip malformed URLs
+    if [[ ! "$url" =~ ^https?:// ]]; then
+      echo "Skipping malformed URL: $url"
+      continue
+    fi
+
+    ((current++))
+    echo "Processing [$current/$total_urls]: $url"
+
+    eval "yt-dlp $ytdlp_args \"$url\""
+
+    if [ $? -eq 0 ]; then
+      ((success_count++))
+      echo "Success: $url"
+    else
+      ((error_count++))
+      echo "Error: Failed to download $url" >&2
+    fi
+
+    echo "--------------------"
+  done < "$url_file"
+
+  echo "Batch download summary:"
+  echo "  Total URLs: $total_urls"
+  echo "  Successfully downloaded: $success_count"
+  echo "  Failed: $error_count"
+
+  # Return error if any downloads failed
+  if [ "$error_count" -gt 0 ]; then
+    return 1
+  fi
+
+  return 0
+}' # Batch download YouTube videos from a file containing URLs
+
+#------------------------------------------------------------------------------
+# Playlist Download Aliases
+#------------------------------------------------------------------------------
+
+alias yt-playlist='() {
+  echo -e "Download a YouTube playlist.\nUsage:\n  yt-playlist <playlist_url> [options]\n\nOptions:\n  -o, --output_dir DIR   : Output directory (default: current directory)\n  -f, --format FORMAT    : Video format/quality (default: best)\n                          Common formats: best, 720p, 1080p, 2160p\n  -s, --subtitles        : Download subtitles if available\n  -t, --thumbnail        : Download thumbnail for each video\n  -i, --items RANGE      : Download specific items (e.g., 1-3,7,10-12)\n  -r, --reverse          : Download playlist in reverse order\n  -l, --limit NUMBER     : Limit number of videos to download\n  -h, --help             : Show this help message\n\nExamples:\n  yt-playlist https://www.youtube.com/playlist?list=PLxxx\n  yt-playlist https://www.youtube.com/playlist?list=PLxxx -f 720p -s -t\n  yt-playlist https://www.youtube.com/playlist?list=PLxxx -i 1-5,10 -o ~/Videos"
+
+  # Variables with default values
+  local url=""
+  local output_dir="."
+  local format="best"
+  local download_subs=false
+  local download_thumbnail=false
+  local playlist_items=""
+  local reverse_order=false
+  local download_limit=""
+  local show_help=false
+  local ytdlp_args=""
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output_dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -f|--format)
+        format="$2"
+        shift 2
+        ;;
+      -s|--subtitles)
+        download_subs=true
+        shift
+        ;;
+      -t|--thumbnail)
+        download_thumbnail=true
+        shift
+        ;;
+      -i|--items)
+        playlist_items="$2"
+        shift 2
+        ;;
+      -r|--reverse)
+        reverse_order=true
+        shift
+        ;;
+      -l|--limit)
+        download_limit="$2"
+        shift 2
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL
+        if [ -z "$url" ]; then
+          url="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL provided
+  if $show_help || [ -z "$url" ]; then
+    return 1
+  fi
+
+  # Validate URL and check for yt-dlp
+  _yt_validate_url "$url" || return 1
+  _yt_check_ytdlp || return 1
+
+  # Validate output directory
+  _yt_validate_dir "$output_dir" "create" || return 1
+
+  # Prepare format specification
+  local format_arg=""
+  case "$format" in
+    best)
+      format_arg="bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"
+      ;;
+    720p)
+      format_arg="bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720][ext=mp4]/best"
+      ;;
+    1080p)
+      format_arg="bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[height<=1080][ext=mp4]/best"
+      ;;
+    2160p)
+      format_arg="bestvideo[height<=2160][ext=mp4]+bestaudio[ext=m4a]/best[height<=2160][ext=mp4]/best"
+      ;;
+    *)
+      format_arg="$format"
+      ;;
+  esac
+
+  # Build yt-dlp arguments
+  ytdlp_args="$ytdlp_args -f \"$format_arg\" -o \"$output_dir/%(playlist_index)s-%(title)s.%(ext)s\" --yes-playlist"
+
+  if $download_subs; then
+    ytdlp_args="$ytdlp_args --write-auto-sub --sub-lang en --convert-subs srt"
+  fi
+
+  if $download_thumbnail; then
+    ytdlp_args="$ytdlp_args --write-thumbnail"
+  fi
+
+  if [ -n "$playlist_items" ]; then
+    ytdlp_args="$ytdlp_args --playlist-items \"$playlist_items\""
+  fi
+
+  if $reverse_order; then
+    ytdlp_args="$ytdlp_args --playlist-reverse"
+  fi
+
+  if [ -n "$download_limit" ]; then
+    ytdlp_args="$ytdlp_args --max-downloads $download_limit"
+  fi
+
+  # Execute the download
+  echo "Downloading playlist from $url with format: $format"
+  eval "yt-dlp $ytdlp_args \"$url\""
+
+  if [ $? -eq 0 ]; then
+    echo "Playlist download completed successfully to $output_dir"
+  else
+    echo "Error: Playlist download failed" >&2
+    return 1
+  fi
+}' # Download a YouTube playlist with options
+
+#------------------------------------------------------------------------------
+# Thumbnail Download Aliases
+#------------------------------------------------------------------------------
+
+alias yt-thumbnail='() {
+  echo -e "Download thumbnails from YouTube videos.\nUsage:\n  yt-thumbnail <video_url> [options]\n\nOptions:\n  -o, --output_dir DIR   : Output directory (default: current directory)\n  -q, --quality QUALITY  : Thumbnail quality (default: max)\n                          Options: default, medium, high, max\n  -h, --help             : Show this help message\n\nExamples:\n  yt-thumbnail https://youtu.be/dQw4w9WgXcQ\n  yt-thumbnail https://youtu.be/dQw4w9WgXcQ -q high -o ~/Pictures/thumbnails"
+
+  # Variables with default values
+  local url=""
+  local output_dir="."
+  local quality="max"
+  local show_help=false
+  local ytdlp_args=""
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output_dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -q|--quality)
+        quality="$2"
+        shift 2
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL
+        if [ -z "$url" ]; then
+          url="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL provided
+  if $show_help || [ -z "$url" ]; then
+    return 1
+  fi
+
+  # Validate URL and check for yt-dlp
+  _yt_validate_url "$url" || return 1
+  _yt_check_ytdlp || return 1
+
+  # Validate output directory
+  _yt_validate_dir "$output_dir" "create" || return 1
+
+  # Map quality to corresponding format
+  local thumbnail_quality=""
+  case "$quality" in
+    default)
+      thumbnail_quality="0"
+      ;;
+    medium)
+      thumbnail_quality="1"
+      ;;
+    high)
+      thumbnail_quality="2"
+      ;;
+    max)
+      thumbnail_quality="3"
+      ;;
+    *)
+      echo "Error: Invalid quality option. Use default, medium, high, or max" >&2
+      return 1
+      ;;
+  esac
+
+  # Build yt-dlp arguments for downloading only the thumbnail
+  ytdlp_args="--write-thumbnail --skip-download -o \"$output_dir/%(title)s.%(ext)s\""
+
+  # Execute the download
+  echo "Downloading thumbnail from $url with quality: $quality"
+  eval "yt-dlp $ytdlp_args \"$url\""
+
+  if [ $? -eq 0 ]; then
+    echo "Thumbnail download completed successfully to $output_dir"
+
+    # Convert webp thumbnails to jpg if available
+    find "$output_dir" -name "*.webp" -type f -print0 | while IFS= read -r -d "" webp_file; do
+      echo "Converting $webp_file to jpg format"
+      jpg_file="${webp_file%.webp}.jpg"
+
+      if command -v convert &> /dev/null; then
+        convert "$webp_file" "$jpg_file" && rm "$webp_file"
+      elif command -v ffmpeg &> /dev/null; then
+        ffmpeg -i "$webp_file" "$jpg_file" -y && rm "$webp_file"
+      else
+        echo "Warning: Neither ImageMagick nor ffmpeg is available for WebP conversion" >&2
+      fi
+    done
+  else
+    echo "Error: Thumbnail download failed" >&2
+    return 1
+  fi
+}' # Download thumbnails from YouTube videos
+
+alias yt-batch-thumbnail='() {
+  echo -e "Batch download thumbnails from multiple YouTube videos.\nUsage:\n  yt-batch-thumbnail <url_file_path> [options]\n\nOptions:\n  -o, --output_dir DIR   : Output directory (default: current directory)\n  -q, --quality QUALITY  : Thumbnail quality (default: max)\n                          Options: default, medium, high, max\n  -h, --help             : Show this help message\n\nExamples:\n  yt-batch-thumbnail urls.txt\n  yt-batch-thumbnail urls.txt -q high -o ~/Pictures/thumbnails"
+
+  # Variables with default values
+  local url_file=""
+  local output_dir="."
+  local quality="max"
+  local show_help=false
+  local ytdlp_args=""
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output_dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -q|--quality)
+        quality="$2"
+        shift 2
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL file
+        if [ -z "$url_file" ]; then
+          url_file="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL file provided
+  if $show_help || [ -z "$url_file" ]; then
+    return 1
+  fi
+
+  # Check if the URL file exists
+  if [ ! -f "$url_file" ]; then
+    echo "Error: File \"$url_file\" does not exist" >&2
+    return 1
+  fi
+
+  # Check for yt-dlp
+  _yt_check_ytdlp || return 1
+
+  # Validate output directory
+  _yt_validate_dir "$output_dir" "create" || return 1
+
+  # Map quality to corresponding format
+  local thumbnail_quality=""
+  case "$quality" in
+    default)
+      thumbnail_quality="0"
+      ;;
+    medium)
+      thumbnail_quality="1"
+      ;;
+    high)
+      thumbnail_quality="2"
+      ;;
+    max)
+      thumbnail_quality="3"
+      ;;
+    *)
+      echo "Error: Invalid quality option. Use default, medium, high, or max" >&2
+      return 1
+      ;;
+  esac
+
+  # Build yt-dlp arguments for downloading only the thumbnail
+  ytdlp_args="--write-thumbnail --skip-download -o \"$output_dir/%(title)s.%(ext)s\""
+
+  # Count total URLs
+  local total_urls=$(grep -c "^https\?://" "$url_file")
+  local success_count=0
+  local error_count=0
+  local current=0
+
+  while IFS= read -r url || [ -n "$url" ]; do
+    # Skip empty lines or comments
+    if [[ -z "$url" || "$url" =~ ^# ]]; then
+      continue
+    fi
+
+    # Skip malformed URLs
+    if [[ ! "$url" =~ ^https?:// ]]; then
+      echo "Skipping malformed URL: $url"
+      continue
+    fi
+
+    ((current++))
+    echo "Processing [$current/$total_urls]: $url"
+
+    eval "yt-dlp $ytdlp_args \"$url\""
+
+    if [ $? -eq 0 ]; then
+      ((success_count++))
+      echo "Success: $url"
+    else
+      ((error_count++))
+      echo "Error: Failed to download thumbnail from $url" >&2
+    fi
+
+    echo "--------------------"
+  done < "$url_file"
+
+  # Convert webp thumbnails to jpg if available
+  find "$output_dir" -name "*.webp" -type f -print0 | while IFS= read -r -d "" webp_file; do
+    echo "Converting $webp_file to jpg format"
+    jpg_file="${webp_file%.webp}.jpg"
+
+    if command -v convert &> /dev/null; then
+      convert "$webp_file" "$jpg_file" && rm "$webp_file"
+    elif command -v ffmpeg &> /dev/null; then
+      ffmpeg -i "$webp_file" "$jpg_file" -y && rm "$webp_file"
+    else
+      echo "Warning: Neither ImageMagick nor ffmpeg is available for WebP conversion" >&2
+    fi
+  done
+
+  echo "Batch thumbnail download summary:"
+  echo "  Total URLs: $total_urls"
+  echo "  Successfully downloaded: $success_count"
+  echo "  Failed: $error_count"
+
+  # Return error if any downloads failed
+  if [ "$error_count" -gt 0 ]; then
+    return 1
+  fi
+
+  return 0
+}' # Batch download thumbnails from multiple YouTube videos
+
+#------------------------------------------------------------------------------
+# Audio Extraction Aliases
+#------------------------------------------------------------------------------
+
+alias yt-audio='() {
+  echo -e "Extract audio from YouTube videos.\nUsage:\n  yt-audio <video_url> [options]\n\nOptions:\n  -o, --output_dir DIR   : Output directory (default: current directory)\n  -f, --format FORMAT    : Audio format (default: mp3)\n                          Options: mp3, m4a, wav, flac, opus, ogg\n  -q, --quality VALUE    : Audio quality (default: 192)\n                          Values: 64, 128, 192, 256, 320 (kbps)\n  -t, --thumbnail        : Embed thumbnail in audio file\n  -h, --help             : Show this help message\n\nExamples:\n  yt-audio https://youtu.be/dQw4w9WgXcQ\n  yt-audio https://youtu.be/dQw4w9WgXcQ -f wav -q 320 -t\n  yt-audio https://youtu.be/dQw4w9WgXcQ --output_dir ~/Music --format mp3"
+
+  # Variables with default values
+  local url=""
+  local output_dir="."
+  local format="mp3"
+  local quality="192"
+  local embed_thumbnail=false
+  local show_help=false
+  local ytdlp_args=""
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output_dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -f|--format)
+        format="$2"
+        shift 2
+        ;;
+      -q|--quality)
+        quality="$2"
+        shift 2
+        ;;
+      -t|--thumbnail)
+        embed_thumbnail=true
+        shift
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL
+        if [ -z "$url" ]; then
+          url="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL provided
+  if $show_help || [ -z "$url" ]; then
+    return 1
+  fi
+
+  # Validate URL and check for yt-dlp and ffmpeg
+  _yt_validate_url "$url" || return 1
+  _yt_check_ytdlp || return 1
+  _yt_check_ffmpeg || return 1
+
+  # Validate output directory
+  _yt_validate_dir "$output_dir" "create" || return 1
+
+  # Validate format
+  case "$format" in
+    mp3|m4a|wav|flac|opus|ogg)
+      ;;
+    *)
+      echo "Error: Unsupported audio format. Use mp3, m4a, wav, flac, opus, or ogg" >&2
+      return 1
+      ;;
+  esac
+
+  # Validate quality
+  if ! [[ "$quality" =~ ^[0-9]+$ ]] || [ "$quality" -lt 0 ]; then
+    echo "Error: Quality must be a positive number" >&2
+    return 1
+  fi
+
+  # Build yt-dlp arguments for audio extraction
+  ytdlp_args="-x --audio-format $format --audio-quality $quality -o \"$output_dir/%(title)s.%(ext)s\""
+
+  if $embed_thumbnail; then
+    ytdlp_args="$ytdlp_args --embed-thumbnail"
+  fi
+
+  # Execute the audio extraction
+  echo "Extracting audio from $url in $format format with ${quality}kbps quality"
+  eval "yt-dlp $ytdlp_args \"$url\""
+
+  if [ $? -eq 0 ]; then
+    echo "Audio extraction completed successfully to $output_dir"
+  else
+    echo "Error: Audio extraction failed" >&2
+    return 1
+  fi
+}' # Extract audio from YouTube videos
+
+alias yt-batch-audio='() {
+  echo -e "Batch extract audio from multiple YouTube videos.\nUsage:\n  yt-batch-audio <url_file_path> [options]\n\nOptions:\n  -o, --output_dir DIR   : Output directory (default: current directory)\n  -f, --format FORMAT    : Audio format (default: mp3)\n                          Options: mp3, m4a, wav, flac, opus, ogg\n  -q, --quality VALUE    : Audio quality (default: 192)\n                          Values: 64, 128, 192, 256, 320 (kbps)\n  -t, --thumbnail        : Embed thumbnail in audio files\n  -h, --help             : Show this help message\n\nExamples:\n  yt-batch-audio urls.txt\n  yt-batch-audio urls.txt -f wav -q 320 -t\n  yt-batch-audio urls.txt --output_dir ~/Music --format mp3"
+
+  # Variables with default values
+  local url_file=""
+  local output_dir="."
+  local format="mp3"
+  local quality="192"
+  local embed_thumbnail=false
+  local show_help=false
+  local ytdlp_args=""
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output_dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -f|--format)
+        format="$2"
+        shift 2
+        ;;
+      -q|--quality)
+        quality="$2"
+        shift 2
+        ;;
+      -t|--thumbnail)
+        embed_thumbnail=true
+        shift
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL file
+        if [ -z "$url_file" ]; then
+          url_file="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL file provided
+  if $show_help || [ -z "$url_file" ]; then
+    return 1
+  fi
+
+  # Check if the URL file exists
+  if [ ! -f "$url_file" ]; then
+    echo "Error: File \"$url_file\" does not exist" >&2
+    return 1
+  fi
+
+  # Check for yt-dlp and ffmpeg
+  _yt_check_ytdlp || return 1
+  _yt_check_ffmpeg || return 1
+
+  # Validate output directory
+  _yt_validate_dir "$output_dir" "create" || return 1
+
+  # Validate format
+  case "$format" in
+    mp3|m4a|wav|flac|opus|ogg)
+      ;;
+    *)
+      echo "Error: Unsupported audio format. Use mp3, m4a, wav, flac, opus, or ogg" >&2
+      return 1
+      ;;
+  esac
+
+  # Validate quality
+  if ! [[ "$quality" =~ ^[0-9]+$ ]] || [ "$quality" -lt 0 ]; then
+    echo "Error: Quality must be a positive number" >&2
+    return 1
+  fi
+
+  # Build yt-dlp arguments for audio extraction
+  ytdlp_args="-x --audio-format $format --audio-quality $quality -o \"$output_dir/%(title)s.%(ext)s\""
+
+  if $embed_thumbnail; then
+    ytdlp_args="$ytdlp_args --embed-thumbnail"
+  fi
+
+  # Count total URLs
+  local total_urls=$(grep -c "^https\?://" "$url_file")
+  local success_count=0
+  local error_count=0
+  local current=0
+
+  while IFS= read -r url || [ -n "$url" ]; do
+    # Skip empty lines or comments
+    if [[ -z "$url" || "$url" =~ ^# ]]; then
+      continue
+    fi
+
+    # Skip malformed URLs
+    if [[ ! "$url" =~ ^https?:// ]]; then
+      echo "Skipping malformed URL: $url"
+      continue
+    fi
+
+    ((current++))
+    echo "Processing [$current/$total_urls]: $url"
+
+    eval "yt-dlp $ytdlp_args \"$url\""
+
+    if [ $? -eq 0 ]; then
+      ((success_count++))
+      echo "Success: $url"
+    else
+      ((error_count++))
+      echo "Error: Failed to extract audio from $url" >&2
+    fi
+
+    echo "--------------------"
+  done < "$url_file"
+
+  echo "Batch audio extraction summary:"
+  echo "  Total URLs: $total_urls"
+  echo "  Successfully extracted: $success_count"
+  echo "  Failed: $error_count"
+
+  # Return error if any extractions failed
+  if [ "$error_count" -gt 0 ]; then
+    return 1
+  fi
+
+  return 0
+}' # Batch extract audio from multiple YouTube videos
+
+alias yt-playlist-audio='() {
+  echo -e "Extract audio from a YouTube playlist.\nUsage:\n  yt-playlist-audio <playlist_url> [options]\n\nOptions:\n  -o, --output_dir DIR   : Output directory (default: current directory)\n  -f, --format FORMAT    : Audio format (default: mp3)\n                          Options: mp3, m4a, wav, flac, opus, ogg\n  -q, --quality VALUE    : Audio quality (default: 192)\n                          Values: 64, 128, 192, 256, 320 (kbps)\n  -t, --thumbnail        : Embed thumbnail in audio files\n  -i, --items RANGE      : Download specific items (e.g., 1-3,7,10-12)\n  -r, --reverse          : Download playlist in reverse order\n  -l, --limit NUMBER     : Limit number of videos to download\n  -h, --help             : Show this help message\n\nExamples:\n  yt-playlist-audio https://www.youtube.com/playlist?list=PLxxx\n  yt-playlist-audio https://www.youtube.com/playlist?list=PLxxx -f wav -q 320 -t\n  yt-playlist-audio https://www.youtube.com/playlist?list=PLxxx -i 1-5,10 -o ~/Music"
+
+  # Variables with default values
+  local url=""
+  local output_dir="."
+  local format="mp3"
+  local quality="192"
+  local embed_thumbnail=false
+  local playlist_items=""
+  local reverse_order=false
+  local download_limit=""
+  local show_help=false
+  local ytdlp_args=""
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output_dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -f|--format)
+        format="$2"
+        shift 2
+        ;;
+      -q|--quality)
+        quality="$2"
+        shift 2
+        ;;
+      -t|--thumbnail)
+        embed_thumbnail=true
+        shift
+        ;;
+      -i|--items)
+        playlist_items="$2"
+        shift 2
+        ;;
+      -r|--reverse)
+        reverse_order=true
+        shift
+        ;;
+      -l|--limit)
+        download_limit="$2"
+        shift 2
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL
+        if [ -z "$url" ]; then
+          url="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL provided
+  if $show_help || [ -z "$url" ]; then
+    return 1
+  fi
+
+  # Validate URL and check for yt-dlp and ffmpeg
+  _yt_validate_url "$url" || return 1
+  _yt_check_ytdlp || return 1
+  _yt_check_ffmpeg || return 1
+
+  # Validate output directory
+  _yt_validate_dir "$output_dir" "create" || return 1
+
+  # Validate format
+  case "$format" in
+    mp3|m4a|wav|flac|opus|ogg)
+      ;;
+    *)
+      echo "Error: Unsupported audio format. Use mp3, m4a, wav, flac, opus, or ogg" >&2
+      return 1
+      ;;
+  esac
+
+  # Validate quality
+  if ! [[ "$quality" =~ ^[0-9]+$ ]] || [ "$quality" -lt 0 ]; then
+    echo "Error: Quality must be a positive number" >&2
+    return 1
+  fi
+
+  # Build yt-dlp arguments for audio extraction
+  ytdlp_args="-x --audio-format $format --audio-quality $quality -o \"$output_dir/%(playlist_index)s-%(title)s.%(ext)s\" --yes-playlist"
+
+  if $embed_thumbnail; then
+    ytdlp_args="$ytdlp_args --embed-thumbnail"
+  fi
+
+  if [ -n "$playlist_items" ]; then
+    ytdlp_args="$ytdlp_args --playlist-items \"$playlist_items\""
+  fi
+
+  if $reverse_order; then
+    ytdlp_args="$ytdlp_args --playlist-reverse"
+  fi
+
+  if [ -n "$download_limit" ]; then
+    ytdlp_args="$ytdlp_args --max-downloads $download_limit"
+  fi
+
+  # Execute the audio extraction
+  echo "Extracting audio from playlist $url in $format format with ${quality}kbps quality"
+  eval "yt-dlp $ytdlp_args \"$url\""
+
+  if [ $? -eq 0 ]; then
+    echo "Playlist audio extraction completed successfully to $output_dir"
+  else
+    echo "Error: Playlist audio extraction failed" >&2
+    return 1
+  fi
+}' # Extract audio from a YouTube playlist
+
+#------------------------------------------------------------------------------
+# Video Information Aliases
+#------------------------------------------------------------------------------
+
+alias yt-info='() {
+  echo -e "Get information about YouTube videos.\nUsage:\n  yt-info <video_url> [options]\n\nOptions:\n  -f, --format           : Show available formats\n  -s, --simple           : Show simplified information\n  -j, --json             : Output in JSON format\n  -h, --help             : Show this help message\n\nExamples:\n  yt-info https://youtu.be/dQw4w9WgXcQ\n  yt-info https://youtu.be/dQw4w9WgXcQ -f\n  yt-info https://youtu.be/dQw4w9WgXcQ --simple"
+
+  # Variables with default values
+  local url=""
+  local show_formats=false
+  local simple_output=false
+  local json_output=false
+  local show_help=false
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f|--format)
+        show_formats=true
+        shift
+        ;;
+      -s|--simple)
+        simple_output=true
+        shift
+        ;;
+      -j|--json)
+        json_output=true
+        shift
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL
+        if [ -z "$url" ]; then
+          url="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL provided
+  if $show_help || [ -z "$url" ]; then
+    return 1
+  fi
+
+  # Validate URL and check for yt-dlp
+  _yt_validate_url "$url" || return 1
+  _yt_check_ytdlp || return 1
+
+  # Build yt-dlp arguments based on options
+  if $show_formats; then
+    echo "Available formats for $url:"
+    yt-dlp -F "$url"
+    return 0
+  elif $json_output; then
+    echo "Video information for $url in JSON format:"
+    yt-dlp --dump-json "$url"
+    return 0
+  elif $simple_output; then
+    echo "Simple information for $url:"
+    yt-dlp --print title --print duration --print view_count --print upload_date --print uploader "$url" | awk "{if(NR==1) print \"Title: \" \$0; if(NR==2) print \"Duration: \" \$0 \" seconds\"; if(NR==3) print \"Views: \" \$0; if(NR==4) print \"Upload date: \" \$0; if(NR==5) print \"Uploader: \" \$0}"
+    return 0
+  else
+    echo "Video information for $url:"
+    yt-dlp --print title --print duration --print view_count --print like_count --print upload_date --print uploader --print description "$url" | awk "{if(NR==1) print \"Title: \" \$0; if(NR==2) print \"Duration: \" \$0 \" seconds\"; if(NR==3) print \"Views: \" \$0; if(NR==4) print \"Likes: \" \$0; if(NR==5) print \"Upload date: \" \$0; if(NR==6) print \"Uploader: \" \$0; if(NR>=7) print \"Description: \" \$0}"
+    return 0
+  fi
+}' # Get information about YouTube videos
+
+alias yt-playlist-info='() {
+  echo -e "Get information about a YouTube playlist.\nUsage:\n  yt-playlist-info <playlist_url> [options]\n\nOptions:\n  -c, --count            : Show only video count\n  -i, --ids              : Show video IDs\n  -t, --titles           : Show only video titles\n  -d, --durations        : Show videos with durations\n  -s, --simple           : Show simplified information\n  -j, --json             : Output in JSON format\n  -h, --help             : Show this help message\n\nExamples:\n  yt-playlist-info https://www.youtube.com/playlist?list=PLxxx\n  yt-playlist-info https://www.youtube.com/playlist?list=PLxxx -c\n  yt-playlist-info https://www.youtube.com/playlist?list=PLxxx --titles"
+
+  # Variables with default values
+  local url=""
+  local count_only=false
+  local ids_only=false
+  local titles_only=false
+  local show_durations=false
+  local simple_output=false
+  local json_output=false
+  local show_help=false
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -c|--count)
+        count_only=true
+        shift
+        ;;
+      -i|--ids)
+        ids_only=true
+        shift
+        ;;
+      -t|--titles)
+        titles_only=true
+        shift
+        ;;
+      -d|--durations)
+        show_durations=true
+        shift
+        ;;
+      -s|--simple)
+        simple_output=true
+        shift
+        ;;
+      -j|--json)
+        json_output=true
+        shift
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL
+        if [ -z "$url" ]; then
+          url="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL provided
+  if $show_help || [ -z "$url" ]; then
+    return 1
+  fi
+
+  # Validate URL and check for yt-dlp
+  _yt_validate_url "$url" || return 1
+  _yt_check_ytdlp || return 1
+
+  # Build yt-dlp arguments based on options
+  if $count_only; then
+    echo "Getting video count in playlist..."
+    video_count=$(yt-dlp --flat-playlist --print id "$url" | wc -l)
+    echo "Playlist contains $video_count videos"
+    return 0
+  elif $ids_only; then
+    echo "Video IDs in playlist:"
+    yt-dlp --flat-playlist --print id "$url"
+    return 0
+  elif $titles_only; then
+    echo "Video titles in playlist:"
+    yt-dlp --flat-playlist --print title "$url"
+    return 0
+  elif $show_durations; then
+    echo "Videos in playlist with durations:"
+    yt-dlp --flat-playlist --print id --print title --print duration_string "$url" | awk "{if(NR%3==1) id=\$0; if(NR%3==2) title=\$0; if(NR%3==0) print title \" [\" \$0 \"] (https://youtu.be/\" id \")\"}"
+    return 0
+  elif $json_output; then
+    echo "Playlist information in JSON format:"
+    yt-dlp --dump-single-json "$url"
+    return 0
+  elif $simple_output; then
+    echo "Simple playlist information:"
+    yt-dlp --flat-playlist --print playlist_title --print playlist_count "$url" | awk "{if(NR==1) print \"Title: \" \$0; if(NR==2) print \"Videos: \" \$0}"
+    return 0
+  else
+    echo "Playlist information:"
+    playlist_info=$(yt-dlp --flat-playlist --print playlist_title --print playlist_uploader --print playlist_count "$url")
+    playlist_title=$(echo "$playlist_info" | head -n 1)
+    playlist_uploader=$(echo "$playlist_info" | head -n 2 | tail -n 1)
+    playlist_count=$(echo "$playlist_info" | head -n 3 | tail -n 1)
+
+    echo "Title: $playlist_title"
+    echo "Uploader: $playlist_uploader"
+    echo "Videos: $playlist_count"
+    echo "URL: $url"
+
+    echo "First 5 videos in playlist:"
+    yt-dlp --flat-playlist --print title --max-downloads 5 "$url" | awk "{print \"- \" \$0}"
+
+    return 0
+  fi
+}' # Get information about a YouTube playlist
+
+#------------------------------------------------------------------------------
+# Subtitle Download Aliases
+#------------------------------------------------------------------------------
+
+alias yt-subtitle='() {
+  echo -e "Download subtitles from YouTube videos.\nUsage:\n  yt-subtitle <video_url> [options]\n\nOptions:\n  -o, --output_dir DIR   : Output directory (default: current directory)\n  -l, --lang LANG        : Subtitle language (default: en)\n                          Examples: en, fr, es, de, ja, zh\n  -a, --auto             : Download auto-generated subtitles\n  -f, --format FORMAT    : Subtitle format (default: srt)\n                          Options: srt, vtt, ass, lrc\n  -h, --help             : Show this help message\n\nExamples:\n  yt-subtitle https://youtu.be/dQw4w9WgXcQ\n  yt-subtitle https://youtu.be/dQw4w9WgXcQ -l fr -f vtt\n  yt-subtitle https://youtu.be/dQw4w9WgXcQ --auto --lang en"
+
+  # Variables with default values
+  local url=""
+  local output_dir="."
+  local language="en"
+  local auto_subs=false
+  local format="srt"
+  local show_help=false
+  local ytdlp_args=""
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output_dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -l|--lang)
+        language="$2"
+        shift 2
+        ;;
+      -a|--auto)
+        auto_subs=true
+        shift
+        ;;
+      -f|--format)
+        format="$2"
+        shift 2
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL
+        if [ -z "$url" ]; then
+          url="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL provided
+  if $show_help || [ -z "$url" ]; then
+    return 1
+  fi
+
+  # Validate URL and check for yt-dlp
+  _yt_validate_url "$url" || return 1
+  _yt_check_ytdlp || return 1
+
+  # Validate output directory
+  _yt_validate_dir "$output_dir" "create" || return 1
+
+  # Validate subtitle format
+  case "$format" in
+    srt|vtt|ass|lrc)
+      ;;
+    *)
+      echo "Error: Unsupported subtitle format. Use srt, vtt, ass, or lrc" >&2
+      return 1
+      ;;
+  esac
+
+  # Build yt-dlp arguments for subtitle download
+  if $auto_subs; then
+    ytdlp_args="--skip-download --write-auto-sub --sub-lang $language --convert-subs $format -o \"$output_dir/%(title)s.%(ext)s\""
+  else
+    ytdlp_args="--skip-download --write-sub --sub-lang $language --convert-subs $format -o \"$output_dir/%(title)s.%(ext)s\""
+  fi
+
+  # Execute the subtitle download
+  echo "Downloading ${auto_subs:+auto-generated }subtitles in $language language from $url"
+  eval "yt-dlp $ytdlp_args \"$url\""
+
+  local status=$?
+  if [ $status -eq 0 ]; then
+    echo "Subtitle download completed successfully to $output_dir"
+    return 0
+  elif $auto_subs; then
+    echo "No auto-generated subtitles found, trying manual subtitles..."
+    ytdlp_args="--skip-download --write-sub --sub-lang $language --convert-subs $format -o \"$output_dir/%(title)s.%(ext)s\""
+    eval "yt-dlp $ytdlp_args \"$url\""
+
+    if [ $? -eq 0 ]; then
+      echo "Subtitle download completed successfully to $output_dir"
+      return 0
+    else
+      echo "Error: No subtitles found for this video" >&2
+      return 1
+    fi
+  else
+    echo "No manual subtitles found, trying auto-generated subtitles..."
+    ytdlp_args="--skip-download --write-auto-sub --sub-lang $language --convert-subs $format -o \"$output_dir/%(title)s.%(ext)s\""
+    eval "yt-dlp $ytdlp_args \"$url\""
+
+    if [ $? -eq 0 ]; then
+      echo "Auto-generated subtitle download completed successfully to $output_dir"
+      return 0
+    else
+      echo "Error: No subtitles found for this video" >&2
+      return 1
+    fi
+  fi
+}' # Download subtitles from YouTube videos
+
+alias yt-batch-subtitle='() {
+  echo -e "Batch download subtitles from multiple YouTube videos.\nUsage:\n  yt-batch-subtitle <url_file_path> [options]\n\nOptions:\n  -o, --output_dir DIR   : Output directory (default: current directory)\n  -l, --lang LANG        : Subtitle language (default: en)\n                          Examples: en, fr, es, de, ja, zh\n  -a, --auto             : Download auto-generated subtitles\n  -f, --format FORMAT    : Subtitle format (default: srt)\n                          Options: srt, vtt, ass, lrc\n  -h, --help             : Show this help message\n\nExamples:\n  yt-batch-subtitle urls.txt\n  yt-batch-subtitle urls.txt -l fr -f vtt\n  yt-batch-subtitle urls.txt --auto --lang en --output_dir ~/Subtitles"
+
+  # Variables with default values
+  local url_file=""
+  local output_dir="."
+  local language="en"
+  local auto_subs=false
+  local format="srt"
+  local show_help=false
+  local ytdlp_args=""
+
+  # Parse all arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--output_dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      -l|--lang)
+        language="$2"
+        shift 2
+        ;;
+      -a|--auto)
+        auto_subs=true
+        shift
+        ;;
+      -f|--format)
+        format="$2"
+        shift 2
+        ;;
+      -h|--help)
+        show_help=true
+        shift
+        ;;
+      *)
+        # First non-option argument is the URL file
+        if [ -z "$url_file" ]; then
+          url_file="$1"
+        else
+          echo "Error: Unexpected argument \"$1\"" >&2
+          show_help=true
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Show help if requested or no URL file provided
+  if $show_help || [ -z "$url_file" ]; then
+    return 1
+  fi
+
+  # Check if the URL file exists
+  if [ ! -f "$url_file" ]; then
+    echo "Error: File \"$url_file\" does not exist" >&2
+    return 1
+  fi
+
+  # Check for yt-dlp
+  _yt_check_ytdlp || return 1
+
+  # Validate output directory
+  _yt_validate_dir "$output_dir" "create" || return 1
+
+  # Validate subtitle format
+  case "$format" in
+    srt|vtt|ass|lrc)
+      ;;
+    *)
+      echo "Error: Unsupported subtitle format. Use srt, vtt, ass, or lrc" >&2
+      return 1
+      ;;
+  esac
+
+  # Build yt-dlp arguments for subtitle download
+  if $auto_subs; then
+    ytdlp_args="--skip-download --write-auto-sub --sub-lang $language --convert-subs $format -o \"$output_dir/%(title)s.%(ext)s\""
+  else
+    ytdlp_args="--skip-download --write-sub --sub-lang $language --convert-subs $format -o \"$output_dir/%(title)s.%(ext)s\""
+  fi
+
+  # Count total URLs
+  local total_urls=$(grep -c "^https\?://" "$url_file")
+  local success_count=0
+  local error_count=0
+  local fallback_count=0
+  local current=0
+
+  while IFS= read -r url || [ -n "$url" ]; do
+    # Skip empty lines or comments
+    if [[ -z "$url" || "$url" =~ ^# ]]; then
+      continue
+    fi
+
+    # Skip malformed URLs
+    if [[ ! "$url" =~ ^https?:// ]]; then
+      echo "Skipping malformed URL: $url"
+      continue
+    fi
+
+    ((current++))
+    echo "Processing [$current/$total_urls]: $url"
+
+    eval "yt-dlp $ytdlp_args \"$url\""
+    local status=$?
+
+    if [ $status -eq 0 ]; then
+      ((success_count++))
+      echo "Success: $url"
+    else
+      # Try the other subtitle type if the first one fails
+      if $auto_subs; then
+        echo "No auto-generated subtitles found, trying manual subtitles..."
+        eval "yt-dlp --skip-download --write-sub --sub-lang $language --convert-subs $format -o \"$output_dir/%(title)s.%(ext)s\" \"$url\""
+        if [ $? -eq 0 ]; then
+          ((fallback_count++))
+          echo "Success with fallback: $url"
+        else
+          ((error_count++))
+          echo "Error: No subtitles found for $url" >&2
+        fi
+      else
+        echo "No manual subtitles found, trying auto-generated subtitles..."
+        eval "yt-dlp --skip-download --write-auto-sub --sub-lang $language --convert-subs $format -o \"$output_dir/%(title)s.%(ext)s\" \"$url\""
+        if [ $? -eq 0 ]; then
+          ((fallback_count++))
+          echo "Success with fallback: $url"
+        else
+          ((error_count++))
+          echo "Error: No subtitles found for $url" >&2
+        fi
+      fi
+    fi
+
+    echo "--------------------"
+  done < "$url_file"
+
+  echo "Batch subtitle download summary:"
+  echo "  Total URLs: $total_urls"
+  echo "  Successfully downloaded: $success_count"
+  echo "  Successfully downloaded with fallback: $fallback_count"
+  echo "  Failed: $error_count"
+
+  # Return error if any downloads failed
+  if [ "$error_count" -gt 0 ]; then
+    return 1
+  fi
+
+  return 0
+}' # Batch download subtitles from multiple YouTube videos
+
+#------------------------------------------------------------------------------
+# Help Function
+#------------------------------------------------------------------------------
+
+alias yt-help='() {
+  echo "YouTube Aliases Help"
+  echo "===================="
+  echo ""
+  echo "Video Download:"
+  echo "  yt-download <url> [options]         - Download a YouTube video"
+  echo "  yt-batch-download <file> [options]  - Batch download YouTube videos from a file"
+  echo ""
+  echo "Playlist Download:"
+  echo "  yt-playlist <url> [options]         - Download a YouTube playlist"
+  echo ""
+  echo "Audio Extraction:"
+  echo "  yt-audio <url> [options]            - Extract audio from YouTube videos"
+  echo "  yt-batch-audio <file> [options]     - Batch extract audio from multiple YouTube videos"
+  echo "  yt-playlist-audio <url> [options]   - Extract audio from a YouTube playlist"
+  echo ""
+  echo "Video Information:"
+  echo "  yt-info <url> [options]             - Get information about YouTube videos"
+  echo "  yt-playlist-info <url> [options]    - Get information about a YouTube playlist"
+  echo ""
+  echo "Thumbnail Download:"
+  echo "  yt-thumbnail <url> [options]        - Download thumbnails from YouTube videos"
+  echo "  yt-batch-thumbnail <file> [options] - Batch download thumbnails from multiple videos"
+  echo ""
+  echo "Subtitle Download:"
+  echo "  yt-subtitle <url> [options]         - Download subtitles from YouTube videos"
+  echo "  yt-batch-subtitle <file> [options]  - Batch download subtitles from multiple videos"
+  echo ""
+  echo "For more detailed help on any command, run the command without arguments"
+}' # Display help information about all YouTube commands
+
+alias youtube-help='() {
+  yt-help
+}' # Alias to call the YouTube help function

--- a/shells/oh-my-zsh/tools/install_omz_aliases.sh
+++ b/shells/oh-my-zsh/tools/install_omz_aliases.sh
@@ -166,7 +166,7 @@ if [ "$CN" = "true" ]; then
   remote_base_url="$remote_base_url_cn"
 fi
 
-default_alias_files="archive_aliases.zsh,audio_aliases.zsh,base_aliases.zsh,brew_aliases.zsh,bria_aliases.zsh,directory_aliases.zsh,docker_aliases.zsh,docker_app_aliases.zsh,filesystem_aliases.zsh,git_aliases.zsh,help_aliases.zsh,image_aliases.zsh,minio_aliases.zsh,network_aliases.zsh,notification_aliases.zsh,other_aliases.zsh,srv_aliases.zsh,ssh_aliases.zsh,ssh_server_aliases.zsh,ssl_aliases.zsh,system_aliases.zsh,tcpdump_aliases.zsh,url_aliases.zsh,video_aliases.zsh,vps_aliases.zsh,web_aliases.zsh,zsh_config_aliases.zsh,environment_aliases.zsh,calc_aliases.zsh,log_aliases.zsh,mysql_aliases.zsh,group_aliases.zsh"
+default_alias_files="archive_aliases.zsh,audio_aliases.zsh,base_aliases.zsh,brew_aliases.zsh,bria_aliases.zsh,directory_aliases.zsh,docker_aliases.zsh,docker_app_aliases.zsh,filesystem_aliases.zsh,git_aliases.zsh,help_aliases.zsh,image_aliases.zsh,minio_aliases.zsh,network_aliases.zsh,notification_aliases.zsh,other_aliases.zsh,srv_aliases.zsh,ssh_aliases.zsh,ssh_server_aliases.zsh,ssl_aliases.zsh,system_aliases.zsh,tcpdump_aliases.zsh,url_aliases.zsh,video_aliases.zsh,vps_aliases.zsh,web_aliases.zsh,zsh_config_aliases.zsh,environment_aliases.zsh,calc_aliases.zsh,log_aliases.zsh,mysql_aliases.zsh,group_aliases.zsh,download_aliases.zsh"
 
 # Parse command-line arguments
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
Streamline video aliases by removing outdated YouTube commands and introducing a new set of aliases for downloading YouTube content using yt-dlp. Enhance documentation to reflect these changes and support file download operations.